### PR TITLE
Do not treat `extra` as an error.

### DIFF
--- a/bin/tap-difflet
+++ b/bin/tap-difflet
@@ -67,8 +67,7 @@ tap.on('extra', function(res) {
     try {
       res = yaml.safeLoad(res);
     } catch (e) {}
-    errors.push(chalk.gray(res));
-    output(errors[errors.length-1]);
+    output(chalk.yellow(res));
     output('\n');
   }
 });


### PR DESCRIPTION
I might be missing something in the spec, but I don't think `extra` maps to an error state? `tap-spec` only treats it as additional output: https://github.com/scottcorgan/tap-spec/blob/master/index.js#L92

@namuol what do you think? Was there a reason behind `extra -> error`. If you agree with this I will add tests and defer to you for review.
