### PR TITLE
Fix console.* causing incorrect test failures

### DIFF
--- a/bin/tap-difflet
+++ b/bin/tap-difflet
@@ -64,12 +64,14 @@ tap.on('assert', function(res) {
 
 tap.on('extra', function(res) {
   if (res !== '') {
-    try {
-      res = yaml.safeLoad(res);
-    } catch (e) {}
-    errors.push(chalk.gray(res));
-    output(errors[errors.length-1]);
-    output('\n');
+    if (res.indexOf('---') === 0){
+      errors.push(chalk.gray(res));
+      output(errors[errors.length-1]);
+      output('\n');
+    } else {
+      output('    ' + chalk.blue(res));
+      output('\n');
+    }
   }
 });
 

--- a/test/pass.js
+++ b/test/pass.js
@@ -13,3 +13,9 @@ test('2 === 2', function(assert) {
   assert.plan(1);
   assert.equal(2, 2);
 });
+
+test('Does not error with comment', function(assert){
+  assert.plan(1);
+  console.log('a comment');
+  assert.pass('can console.log');
+})


### PR DESCRIPTION
Previously, using `console.log` anywhere would cause a test failure. This, correctly, shows it as a comment, and removes a call to a library that was never defined.
