### PR TITLE
Added the notion of pessimistic usage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: pass fail test
+.PHONY: pass fail mix test
 
 TAP = ./node_modules/tape/bin/tape
 MIN = ./bin/tap-difflet
@@ -8,5 +8,11 @@ pass:
 
 fail:
 	@$(TAP) test/fail.js | $(MIN)
+
+mix:
+	@$(TAP) test/mix.js | $(MIN)
+
+mixp:
+	@$(TAP) test/mix.js | $(MIN) -p 
 
 test: pass fail

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ npm install tap-difflet --save-dev
 tape test/*.js | tap-difflet
 ~~~
 
+For pessimistic usage specify -p or --pessimist - this will only output the errors and the summary.
+
+~~~ text
+tape test/*.js | tap-difflet -p
+~~~
+
 ## Output
 
 ![tap-difflet](http://i.imgur.com/8uFAvXU.png)

--- a/bin/tap-difflet
+++ b/bin/tap-difflet
@@ -27,7 +27,7 @@ function userSpecifiedPessimistic (args) {
     if (args[ai] === '-p' || args[ai] === '--pessimist') {
       return true;
     }
-  }  
+  }
 
   return false;
 };
@@ -43,41 +43,49 @@ if (userSpecifiedPessimistic(process.argv)) {
         originalOut.push(buffer[bi]);
       }
     }
-    
+
     buffer = null;
     anAssertFailed = false;
     out = originalOut;
-    
-    if (commentType(comment) === '') {
+
+    if (getCommentType(comment) === CommentType.OTHER) {
       buffer = [];
       out = buffer;
-    }    
+    }
   });
-  
+
   tap.on('assert', function(res) {
     if (!res.ok) {
-      anAssertFailed = true;  
-    }  
+      anAssertFailed = true;
+    }
   });
 }
 
 /* Helpers */
+var CommentType = {
+  OTHER: 1,
+  TESTS: 2,
+  PASS: 3,
+  FAIL: 4,
+  OK: 5
+};
 
-function commentType(comment) {
+function getCommentType(comment) {
   if (/^tests\s+[0-9]+$/gi.test(comment)) {
-    return 'tests';
+    return CommentType.TESTS;
   }
   else if (/^pass\s+[0-9]+$/gi.test(comment)) {
-      return 'pass';
+    return CommentType.PASS;
   }
   else if (/^fail\s+[0-9]+$/gi.test(comment)) {
-      return 'fail';
+    return CommentType.FAIL;
   }
   else if (/^ok$/gi.test(comment)) {
-    return 'ok';
-  } else {
-    return '';
-  }  
+    return CommentType.OK;
+  }
+  else {
+    return CommentType.OTHER;
+  }
 };
 
 function output(str) {
@@ -90,26 +98,26 @@ var timer   = hirestime();
 var errors  = [];
 
 tap.on('comment', function(comment) {
-  
-    switch (commentType(comment)) {
-    case 'tests':
-      output('\n');
-      comment = chalk.white.bold(comment);
-      break;
-    case 'pass':
-      comment = chalk.green.bold(comment);
-      break;
-    case 'fail':
-      comment = chalk.red.bold(comment);
-      break;
-    case 'ok':
-      return;
-    default:
-      output('\n');
-      comment = chalk.white.bold(comment);
-    }
+  var commentType = getCommentType(comment);
+  if (commentType === CommentType.TESTS) {
+    output('\n');
+    comment = chalk.white.bold(comment);
+  }
+  else if (commentType === CommentType.PASS) {
+    comment = chalk.green.bold(comment);
+  }
+  else if (commentType === CommentType.FAIL) {
+    comment = chalk.red.bold(comment);
+  }
+  else if (commentType === CommentType.OK) {
+    return;
+  }
+  else {
+    output('\n');
+    comment = chalk.white.bold(comment);
+  }
 
-    output('  ' + comment + '\n');
+  output('  ' + comment + '\n');
 });
 
 tap.on('assert', function(res) {
@@ -150,10 +158,10 @@ tap.on('results', function(res) {
 
 tap.on('diag', function (diag) {
   var expected, actual, at,
-      gotExpected = true,
-      gotActual = true,
-      gotAt = true,
-      str = '';
+    gotExpected = true,
+    gotActual = true,
+    gotAt = true,
+    str = '';
 
   if (diag.hasOwnProperty('expected')) {
     expected = diag.expected;
@@ -180,15 +188,15 @@ tap.on('diag', function (diag) {
 
   if (gotActual && gotExpected) {
     if (typeof expected !== typeof actual ||
-        typeof expected === "object" && (!actual || !expected)) {
+        typeof expected === 'object' && (!actual || !expected)) {
       str = 'Expected ' + typeof expected + ' but got ' + typeof actual;
-    } else if (typeof expected === "string") {
+    } else if (typeof expected === 'string') {
       if (str.indexOf('\n') >= 0) {
         str = ansidiff.lines(expected, actual);
       } else {
         str = ansidiff.chars(expected, actual);
       }
-    } else if (typeof expected === "object") {
+    } else if (typeof expected === 'object') {
       str = objdiff(expected, actual);
     } else {
       str = chalk.white('Expected ') + chalk.bold(''+expected) + chalk.white(' but got ') + chalk.bold(''+actual);

--- a/bin/tap-difflet
+++ b/bin/tap-difflet
@@ -19,7 +19,66 @@ var tap = parser();
 var out = through();
 var dup = duplexer(tap, out);
 
+
+/* Pessimism */
+
+function userSpecifiedPessimistic (args) {
+  for (var ai=2; ai < args.length; ++ai) {
+    if (args[ai] === '-p' || args[ai] === '--pessimist') {
+      return true;
+    }
+  }  
+
+  return false;
+};
+
+
+if (userSpecifiedPessimistic(process.argv)) {
+  var anAssertFailed = true;
+  var originalOut = out;
+  var buffer = null;
+  tap.on('comment', function(comment) {
+    if (buffer && anAssertFailed) {
+      for (var bi=0; bi<buffer.length; ++bi) {
+        originalOut.push(buffer[bi]);
+      }
+    }
+    
+    buffer = null;
+    anAssertFailed = false;
+    out = originalOut;
+    
+    if (commentType(comment) === '') {
+      buffer = [];
+      out = buffer;
+    }    
+  });
+  
+  tap.on('assert', function(res) {
+    if (!res.ok) {
+      anAssertFailed = true;  
+    }  
+  });
+}
+
 /* Helpers */
+
+function commentType(comment) {
+  if (/^tests\s+[0-9]+$/gi.test(comment)) {
+    return 'tests';
+  }
+  else if (/^pass\s+[0-9]+$/gi.test(comment)) {
+      return 'pass';
+  }
+  else if (/^fail\s+[0-9]+$/gi.test(comment)) {
+      return 'fail';
+  }
+  else if (/^ok$/gi.test(comment)) {
+    return 'ok';
+  } else {
+    return '';
+  }  
+};
 
 function output(str) {
   out.push(str);
@@ -31,22 +90,23 @@ var timer   = hirestime();
 var errors  = [];
 
 tap.on('comment', function(comment) {
-    if (/^tests\s+[0-9]+$/gi.test(comment)) {
-        output('\n');
-        comment = chalk.white.bold(comment);
-    }
-    else if (/^pass\s+[0-9]+$/gi.test(comment)) {
-        comment = chalk.green.bold(comment);
-    }
-    else if (/^fail\s+[0-9]+$/gi.test(comment)) {
-        comment = chalk.red.bold(comment);
-    }
-    else if (/^ok$/gi.test(comment)) {
-        return;
-    }
-    else {
-        output('\n');
-        comment = chalk.white.bold(comment);
+  
+    switch (commentType(comment)) {
+    case 'tests':
+      output('\n');
+      comment = chalk.white.bold(comment);
+      break;
+    case 'pass':
+      comment = chalk.green.bold(comment);
+      break;
+    case 'fail':
+      comment = chalk.red.bold(comment);
+      break;
+    case 'ok':
+      return;
+    default:
+      output('\n');
+      comment = chalk.white.bold(comment);
     }
 
     output('  ' + comment + '\n');

--- a/test/mix.js
+++ b/test/mix.js
@@ -1,0 +1,2 @@
+require ('./pass');
+require ('./fail');


### PR DESCRIPTION
If you specify -p on the command line successful tests will be quietly ignored (you'll still get a summary) - helps cut down the noise when you have a lot of tests.

<img width="645" alt="screen shot 2016-03-09 at 4 51 41 pm" src="https://cloud.githubusercontent.com/assets/327611/13655754/b4ed7770-e616-11e5-9265-0eacea83b419.png">
