### PR TITLE
bin: remove arrow functions for Node 0.12 support

### DIFF
--- a/bin/tap-difflet
+++ b/bin/tap-difflet
@@ -21,7 +21,7 @@ var options = docopt(usage, {
 
 function getOptionsWithoutDashes(options) {
   const transformedOptions = {}
-  Object.keys(options).forEach(key => {
+  Object.keys(options).forEach(function(key) {
     const keyWithoutDashes = key.replace(/^(--|-)/, '');
     transformedOptions[keyWithoutDashes] = options[key];
   });


### PR DESCRIPTION
Commit 22b7aa52f7 ("Move main logic from bin file (#9)") broke
tap-difflet Node 0.10 and 0.12 support due to its use of arrow
functions, which aren't supported by old versions of Node.

This was spotted trying to upgrade node-nanomsg to use tap-difflet.

Fixes #13